### PR TITLE
add desktop notifications and fix some error 500

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ See [hm3.sample.ini](https://github.com/jasonmunro/cypht/blob/master/hm3.sample.
 * **CYPHT_API_LOGIN_KEY** : API key for api login *(default : blank)*
 * **CYPHT_MODULE_RECOVER_SETTINGS** : Enable/disable support for recovering encrypted user settings after IMAP/POP3 password change *(default : disable)*
 * **CYPHT_MODULE_HELLO_WORLD** : Enable/disable support for the example module set with lots of comments *(default : disable)*
+* **CYPHT_MODULE_DESKTOP_NOTIFICATIONS** : Enable/disable support for desktop notifications *(default : disable)*
 * **CYPHT_DEFAULT_SETTING_NO_PASSWORD_SAVE** : Default for saving passwords between logins *(default : false)*
 * **CYPHT_DEFAULT_SETTING_IMAP_PER_PAGE** : Default for number of messages per page for IMAP folders *(default : 20)*
 * **CYPHT_DEFAULT_SETTING_SIMPLE_MSG_PARTS** : Default for IMAP message structure detail on message view page *(default : false)*

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -8,6 +8,7 @@ RUN set -e \
     && apk add --no-cache \
        supervisor \
        nginx \
+       composer \
        # GD
        freetype libpng libjpeg-turbo \
     && apk add --no-cache --virtual .build-deps \
@@ -31,7 +32,9 @@ RUN set -e \
     && mv cypht-master/* ${CYPHT_DEST} \
     && cd /tmp \
     && rm -rf cypht-temp \
-    && apk del .build-deps
+    && apk del .build-deps \
+    && cd ${CYPHT_DEST} \
+    && composer install
 
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY supervisord.conf /etc/supervisord.conf

--- a/image/docker-entrypoint.sh
+++ b/image/docker-entrypoint.sh
@@ -112,6 +112,7 @@ if [ ! -z ${CYPHT_MODULE_DYNAMIC_LOGIN+x} ]; then enable_disable_module dynamic_
 if [ ! -z ${CYPHT_MODULE_API_LOGIN+x} ]; then enable_disable_module api_login ${CYPHT_MODULE_API_LOGIN}; fi
 if [ ! -z ${CYPHT_MODULE_RECOVER_SETTINGS+x} ]; then enable_disable_module recover_settings ${CYPHT_MODULE_RECOVER_SETTINGS}; fi
 if [ ! -z ${CYPHT_MODULE_HELLO_WORLD+x} ]; then enable_disable_module hello_world ${CYPHT_MODULE_HELLO_WORLD}; fi
+if [ ! -z ${CYPHT_MODULE_DESKTOP_NOTIFICATIONS+x} ]; then enable_disable_module desktop_notifications ${CYPHT_MODULE_DESKTOP_NOTIFICATIONS}; fi
 
 # Defaults
 if [ ! -z ${CYPHT_DEFAULT_SETTING_NO_PASSWORD_SAVE+x} ]; then sed -i "s/; default_setting_no_password_save=.*/default_setting_no_password_save=${CYPHT_DEFAULT_SETTING_NO_PASSWORD_SAVE}/" config.ini; fi


### PR DESCRIPTION
- add desktop notifications
- fix error 500 for some html email messages due to missing vendor packages, by installing them through composer