### PR TITLE
Allow attachments with bigger size (fixes request entity too large)

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -34,7 +34,7 @@ RUN set -e \
     && rm -rf cypht-temp \
     && apk del .build-deps \
     && cd ${CYPHT_DEST} \
-    && composer install
+    && composer install \
     && sed -i 's/post_max_size = 8M/post_max_size = 80M/g' /etc/php7/php.ini \
     && sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 80M/g' /etc/php7/php.ini
 

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -35,8 +35,8 @@ RUN set -e \
     && apk del .build-deps \
     && cd ${CYPHT_DEST} \
     && composer install \
-    && sed -i 's/post_max_size = 8M/post_max_size = 80M/g' /etc/php7/php.ini \
-    && sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 80M/g' /etc/php7/php.ini
+    && echo "post_max_size = 80M" >>  /usr/local/etc/php/php.ini \
+    && echo "upload_max_filesize = 80M" >> /usr/local/etc/php/php.ini
 
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY supervisord.conf /etc/supervisord.conf

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -35,6 +35,8 @@ RUN set -e \
     && apk del .build-deps \
     && cd ${CYPHT_DEST} \
     && composer install
+    && sed -i 's/post_max_size = 8M/post_max_size = 80M/g' /etc/php7/php.ini \
+    && sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 80M/g' /etc/php7/php.ini
 
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY supervisord.conf /etc/supervisord.conf

--- a/image/docker-entrypoint.sh
+++ b/image/docker-entrypoint.sh
@@ -194,6 +194,10 @@ attachment_dir=$(sed -n 's/attachment_dir=//p' ${CYPHT_CONFIG_FILE})
 mkdir -p ${attachment_dir}
 chown www-data:www-data ${attachment_dir}
 
+# Nginx Attachment Location
+mkdir -p /var/tmp/nginx
+chown www-data:www-data /var/tmp/nginx
+
 # Application Data Location - create directory
 app_data_dir=$(sed -n 's/app_data_dir=//p' ${CYPHT_CONFIG_FILE})
 mkdir -p ${app_data_dir}

--- a/image/nginx.conf
+++ b/image/nginx.conf
@@ -23,7 +23,7 @@ http {
 		server_name localhost;
 		index index.php;
 		root /var/www;
-		client_max_body_size8M;
+		client_max_body_size 8M;
 		location / {
 			try_files $uri /index.php$is_args$args;
 		}

--- a/image/nginx.conf
+++ b/image/nginx.conf
@@ -23,7 +23,7 @@ http {
 		server_name localhost;
 		index index.php;
 		root /var/www;
-		client_max_body_size 8M;
+		client_max_body_size 80M;
 		location / {
 			try_files $uri /index.php$is_args$args;
 		}

--- a/image/nginx.conf
+++ b/image/nginx.conf
@@ -23,6 +23,7 @@ http {
 		server_name localhost;
 		index index.php;
 		root /var/www;
+		client_max_body_size8M;
 		location / {
 			try_files $uri /index.php$is_args$args;
 		}


### PR DESCRIPTION
Fixes error 413 "Request Entity Too Large" due to nginx config.

Also add correct permission for "/var/tmp/nginx", since nginx saves uploaded attachments there and otherwise will throw an "permission denied" error. 