### PR TITLE
Make it possible to add attachment with bigger size and add missing php extensions required by dev dependencies (phpunit, ...)

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -11,7 +11,7 @@ RUN set -e \
        composer \
        # GD
        freetype libpng libjpeg-turbo \
-       php-session php-fileinfo \
+       php-session php-fileinfo  php-dom php-xml libxml2-dev php-xmlwriter php-tokenizer \
     && apk add --no-cache --virtual .build-deps \
        ca-certificates \
        wget \
@@ -36,7 +36,9 @@ RUN set -e \
     && apk del .build-deps \
     && cd ${CYPHT_DEST} \
     && composer self-update --2 \
-    && composer install
+    && composer install \
+    && echo "post_max_size = 60M" >> /usr/local/etc/php/php.ini \
+    && echo "upload_max_filesize = 50M" >> /usr/local/etc/php/php.ini
 
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY supervisord.conf /etc/supervisord.conf

--- a/image/docker-entrypoint.sh
+++ b/image/docker-entrypoint.sh
@@ -194,6 +194,9 @@ attachment_dir=$(sed -n 's/attachment_dir=//p' ${CYPHT_CONFIG_FILE})
 mkdir -p ${attachment_dir}
 chown www-data:www-data ${attachment_dir}
 
+# Change /var/lib/nginx owner from root to www-data to avoid "permission denied" error.
+chown -R www-data:www-data /var/lib/nginx
+
 # Application Data Location - create directory
 app_data_dir=$(sed -n 's/app_data_dir=//p' ${CYPHT_CONFIG_FILE})
 mkdir -p ${app_data_dir}

--- a/image/nginx.conf
+++ b/image/nginx.conf
@@ -23,6 +23,7 @@ http {
 		server_name localhost;
 		index index.php;
 		root /var/www;
+		client_max_body_size 60M;
 		location / {
 			try_files $uri /index.php$is_args$args;
 		}


### PR DESCRIPTION
Make it possible to add attachment with bigger size and add missing php extensions required by dev dependencies (phpunit, ...) causing the failure of composer dependencies install incluiding require-dev.